### PR TITLE
Adding support for time.Duration

### DIFF
--- a/gonfig_test.go
+++ b/gonfig_test.go
@@ -72,13 +72,15 @@ func (h *HexEncoded) UnmarshalText(t []byte) error {
 }
 
 type TestStruct struct {
-	StringVar  string  `default:"defstring" short:"s" desc:"descstring"`
-	UintVar    uint    `default:"42"`
-	IntVar     int     `default:"-42"`
-	BoolVar1   bool    `short:"b"`
-	BoolVar2   bool    `default:"true"`
-	Float32Var float32 `id:"float" default:"0.50"`
-	Float64Var float64 `default:"0.25"`
+	StringVar    string        `default:"defstring" short:"s" desc:"descstring"`
+	UintVar      uint          `default:"42"`
+	IntVar       int           `default:"-42"`
+	BoolVar1     bool          `short:"b"`
+	BoolVar2     bool          `default:"true"`
+	Float32Var   float32       `id:"float" default:"0.50"`
+	Float64Var   float64       `default:"0.25"`
+	DurationVar1 time.Duration `default:"3s"`
+	DurationVar2 time.Duration `default:"3s" short:"d"`
 
 	Uint8Var      uint8
 	Uint16Var     uint16
@@ -150,6 +152,7 @@ func TestGonfig(t *testing.T) {
 				"--upper1", "TEST",
 				"--hex", "010203",
 				"--bytes1", "AQID",
+				"-d", "5m",
 			},
 			env: map[string]string{
 				"INT8VAR":               "42",
@@ -177,6 +180,8 @@ func TestGonfig(t *testing.T) {
 				assert.EqualValues(t, -0.25, c.Float32Var)
 				assert.EqualValues(t, 0.25, c.Float64Var)
 				assert.EqualValues(t, 0, c.Int8Var)
+				assert.EqualValues(t, 3*time.Second, c.DurationVar1)
+				assert.EqualValues(t, 5*time.Minute, c.DurationVar2)
 				assert.EqualValues(t, 42, c.Int16Var)
 				assert.EqualValues(t, 42, c.Int64Var)
 				assert.EqualValues(t, 42, c.Uint32Var)

--- a/structure.go
+++ b/structure.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 )
 
 const ( // The values for the struct field tags that we use.
@@ -18,6 +19,7 @@ const ( // The values for the struct field tags that we use.
 var ( // Some type variables for comparison.
 	typeOfTextUnmarshaler = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
 	typeOfByteSlice       = reflect.TypeOf([]byte{})
+	typeOfDuration        = reflect.TypeOf(time.Second)
 )
 
 // option holds all useful data and metadata for a single config option variable

--- a/util.go
+++ b/util.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // parseInt parses s to any int type and stores it in v.
@@ -97,6 +98,15 @@ func parseSimpleValue(v reflect.Value, s string) error {
 
 	if v.Type() == typeOfByteSlice {
 		decoded, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return parseError(s, v.Type(), err)
+		}
+		v.Set(reflect.ValueOf(decoded))
+		return nil
+	}
+
+	if v.Type() == typeOfDuration {
+		decoded, err := time.ParseDuration(s)
 		if err != nil {
 			return parseError(s, v.Type(), err)
 		}


### PR DESCRIPTION
For some reason time.Time implements TextUnmarshaler, but time.Duration doesn't (and it's actually quite useful)
