### PR TITLE
make config file optional

### DIFF
--- a/file.go
+++ b/file.go
@@ -41,7 +41,7 @@ func parseMapOpts(j map[string]interface{}, opts []*option) error {
 // it returns a nice error.
 func openConfigFile(path string) ([]byte, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil, fmt.Errorf("config file at %s does not exist", path)
+		return nil, nil
 	}
 
 	content, err := ioutil.ReadFile(path)
@@ -59,6 +59,10 @@ func parseFile(s *setup) error {
 	content, err := openConfigFile(s.configFilePath)
 	if err != nil {
 		return err
+	}
+	// File does not exist, therefore nothing to parse.
+	if content == nil {
+		return nil
 	}
 
 	decoder := s.conf.FileDecoder

--- a/file_test.go
+++ b/file_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseFile_FileNotExist(t *testing.T) {
-	require.Error(t, parseFile(&setup{
-		configFilePath: "/doesntexist.conf",
-	}))
+func TestOpenConfigFile_FileNotExist(t *testing.T) {
+	content, err := openConfigFile("/doesntexist.conf")
+	require.NoError(t, err)
+	require.Nil(t, content)
 }
 
 func TestParseFile_InvalidJSON(t *testing.T) {


### PR DESCRIPTION
Currently if `FileDisable=false` and it does not find a configuration file, gconfig prints an error and exists.

Isn't it a better behavior, if `gconfig` continues, when the file does not exist? Then one can choose if he wants to use a configuration file or not.