### PR TITLE
return abs path

### DIFF
--- a/gonfig.go
+++ b/gonfig.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/spf13/pflag"
 )
@@ -121,7 +122,7 @@ func findConfigFile(s *setup) (string, error) {
 		return "", err
 	}
 	if path != "" {
-		return path, nil
+		return filepath.Abs(path)
 	}
 
 	path, err = lookupConfigFileEnv(s, configOpt)
@@ -129,7 +130,7 @@ func findConfigFile(s *setup) (string, error) {
 		return "", err
 	}
 	if path != "" {
-		return path, nil
+		return filepath.Abs(path)
 	}
 
 	// Ultimately just use the default config file.

--- a/gonfig_test.go
+++ b/gonfig_test.go
@@ -711,7 +711,9 @@ func TestFindConfigFile_WithFlag(t *testing.T) {
 
 	filename, err := findConfigFile(s)
 	require.NoError(t, err)
-	assert.Equal(t, "fromflag.conf", filename)
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	assert.Equal(t, path.Join(wd, "fromflag.conf"), filename)
 }
 
 func TestFindConfigFile_WithEnv(t *testing.T) {
@@ -730,7 +732,9 @@ func TestFindConfigFile_WithEnv(t *testing.T) {
 
 	filename, err := findConfigFile(s)
 	require.NoError(t, err)
-	assert.Equal(t, "fromenv.conf", filename)
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	assert.Equal(t, path.Join(wd, "fromenv.conf"), filename)
 }
 
 func TestFindConfigFile_VariableNotSet(t *testing.T) {


### PR DESCRIPTION
Currently if you try to do something like:

```bash
./example --configfile=myconf.yaml
```

`gonfig` still searches the configuration file in the configured directory.

With this pull request, the above works, and that is probably also what the user expects (at least I was expecting this :smile: )

