### PR TITLE
Add support for omitting options using struct tags

### DIFF
--- a/env.go
+++ b/env.go
@@ -64,6 +64,9 @@ func parseEnv(s *setup) error {
 
 // lookupConfigFileEnv looks for the config file in the environment variables.
 func lookupConfigFileEnv(s *setup, configOpt *option) (string, error) {
+	if configOpt.idopts.Contains("omitenv") {
+		return "", nil
+	}
 	val, found := os.LookupEnv(makeEnvKey(s.conf.EnvPrefix, configOpt.fullIDParts))
 	if !found {
 		return "", nil

--- a/file.go
+++ b/file.go
@@ -16,6 +16,9 @@ import (
 // for configuration file encodings that can decode to such a map.
 func parseMapOpts(j map[string]interface{}, opts []*option) error {
 	for _, opt := range opts {
+		if opt.idopts.Contains("omitfile") {
+			continue
+		}
 		val, set := j[opt.id]
 		if !set {
 			continue

--- a/flags.go
+++ b/flags.go
@@ -87,6 +87,11 @@ func parseFlags(s *setup) error {
 	}
 
 	for _, opt := range s.allOpts {
+		if opt.idopts.Contains("omitflag") {
+			delete(flagsMap, opt.id)
+			continue
+		}
+
 		if opt.isParent {
 			// Parents are skipped, we should only add the children.
 			continue

--- a/gonfig.go
+++ b/gonfig.go
@@ -167,6 +167,8 @@ func setDefaults(s *setup) error {
 //
 // The recognised tags on the exported struct variables are:
 //  - id: the keyword identifier (defaults to lowercase of variable name)
+//    - supports options to ignore config sources (like e.g. encoding/json)
+//      `id:",omitflag,omitfile,omitenv"` will only use the default value
 //  - default: the default value of the variable
 //  - short: the shorthand used for command line flags (like -h)
 //  - desc: the description of the config var, used in --help

--- a/gonfig_test.go
+++ b/gonfig_test.go
@@ -702,6 +702,33 @@ func TestGonfig(t *testing.T) {
 				assert.Equal(t, 52, c.V)
 			},
 		},
+		{
+			desc: "omit args",
+			config: &struct {
+				OmitFlag bool `id:"oflag,omitflag"`
+				OmitEnv  bool `id:"oenv,omitenv"`
+				OmitFile bool `id:"ofile,omitfile"`
+			}{},
+			conf: Conf{FlagDisable: false, FileDisable: false},
+			env: map[string]string{
+				"oenv": "true",
+			},
+			fileContent: `{"ofile": true}`,
+			args:        []string{"--oflag", "true"},
+			shouldError: false,
+			validate: func(t *testing.T, config interface{}) {
+				c, success := config.(*struct {
+					OmitFlag bool `id:"oflag,omitflag"`
+					OmitEnv  bool `id:"oenv,omitenv"`
+					OmitFile bool `id:"ofile,omitfile"`
+				})
+				require.True(t, success)
+
+				assert.Falsef(t, c.OmitFlag, "did not ignore the flag value")
+				assert.Falsef(t, c.OmitEnv, "did not ignore the env value")
+				assert.Falsef(t, c.OmitFile, "did not ignore the file value")
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/help.go
+++ b/help.go
@@ -145,6 +145,9 @@ func writeHelpMessage(s *setup, w io.Writer) {
 		if opt.isParent {
 			continue
 		}
+		if opt.idopts.Contains("omitflag") {
+			continue
+		}
 
 		line := ""
 		if opt.short != "" {


### PR DESCRIPTION
Adds support for tag options `omitflag`/`omitenv`/`omitfile`,
used like `json:",omitempty"`, to ignore the value from the respective
config source using the id struct tag.

Setting `omitflag` also hides the flag from the help output.

If a default value is present it will still be used.

For an example see the test case added in https://github.com/robertgzr/gonfig/tree/omitoptions/gonfig_test.go#L705