### PR TITLE
Allow hiding a field from help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Furthermore, it has the following features:
 - the location of the config file can be passed through command line flags or
   environment variables
 
-- printing help message
+- printing help message (and hiding individual flags)
 
 
 Documentation
@@ -52,6 +52,8 @@ Documentation can be found on godoc.org: https://godoc.org/github.com/stevenroos
 //  - default: the default value of the variable
 //  - short: the shorthand used for command line flags (like -h)
 //  - desc: the description of the config var, used in --help
+//  - opts: comma-separated flags.  Supported flags are:
+//     - hidden: Hides the option from help outputs.
 func Load(c interface{}, conf Conf) error
 
 // Conf is used to specify the intended behavior of gonfig.

--- a/gonfig.go
+++ b/gonfig.go
@@ -170,6 +170,8 @@ func setDefaults(s *setup) error {
 //  - default: the default value of the variable
 //  - short: the shorthand used for command line flags (like -h)
 //  - desc: the description of the config var, used in --help
+//  - opts: comma-separated flags.  Supported flags are:
+//     - hidden: Hides the option from help outputs.
 func Load(c interface{}, conf Conf) error {
 	s := &setup{
 		conf: &conf,

--- a/gonfig_test.go
+++ b/gonfig_test.go
@@ -98,7 +98,7 @@ type TestStruct struct {
 	Int16Var      int16
 	Int32Var      int32 `id:"int-32-var"`
 	Int64Var      int64
-	ByteSliceVar1 []byte `id:"bytes1"`
+	ByteSliceVar1 []byte `id:"bytes1" opts:"hidden"`
 	ByteSliceVar2 []byte `id:"bytes2" default:"AQID"`
 
 	Strings1 []string `default:"string1,string2"`

--- a/help.go
+++ b/help.go
@@ -145,6 +145,9 @@ func writeHelpMessage(s *setup, w io.Writer) {
 		if opt.isParent {
 			continue
 		}
+		if opt.hasFieldOpt(fieldOptHidden) {
+			continue
+		}
 
 		line := ""
 		if opt.short != "" {

--- a/structure_test.go
+++ b/structure_test.go
@@ -70,6 +70,22 @@ func TestOptionFromField(t *testing.T) {
 				desc:        "testing..",
 			},
 		},
+		{
+			"with option",
+			"name",
+			`id:"realname" opts:"hidden" short:"s" default:"defaultvalue" desc:"testing.."`,
+			option{},
+			option{
+				fullIDParts: []string{"realname"},
+				defaultSet:  true,
+				isParent:    false,
+				id:          "realname",
+				short:       "s",
+				defaul:      "defaultvalue",
+				desc:        "testing..",
+				opts:        []string{"hidden"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This adds general support for struct tag options like `",omitempty"` in
encoding/json to the id tag.

Using the `nohelp` option hides a field from the help output.

Replaces #19 