### PR TITLE
fix default for pointer type

### DIFF
--- a/gonfig_test.go
+++ b/gonfig_test.go
@@ -116,7 +116,7 @@ type TestStruct struct {
 	NestedMulti []*NestedTestStruct `id:"nestedmultiid"`
 
 	Marshaled *MarshaledUpper `id:"upper1"`
-	HexData   *HexEncoded     `id:"hex"`
+	HexData   *HexEncoded     `id:"hex" default:"0402"`
 }
 
 func setOS(args []string, env map[string]string) {
@@ -181,6 +181,7 @@ func TestGonfig(t *testing.T) {
 				assert.EqualValues(t, []int{42, 43}, c.Ints1)
 				assert.EqualValues(t, []int{42, 43}, c.Ints2)
 				assert.EqualValues(t, []uint{42, 44}, c.Uints1)
+				assert.EqualValues(t, "0402", c.HexData.String())
 			},
 		},
 		{

--- a/values.go
+++ b/values.go
@@ -118,6 +118,8 @@ func isZero(v reflect.Value) bool {
 			z = z && isZero(v.Field(i))
 		}
 		return z
+	case reflect.Ptr:
+		return isZero(reflect.Indirect(v))
 	}
 	// Compare other types directly:
 	z := reflect.Zero(v.Type())


### PR DESCRIPTION
Minor change to `isZero` to account for pointer types (used for custom unmarshaling).

Fixes #30.